### PR TITLE
refactor(auth): use CLI-based authentication for GCE and Azure

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,8 @@
+version: "2"
+
 linters:
   enable:
     - thelper
-    - gofumpt
     - tparallel
     - unconvert
     - unparam
@@ -9,15 +10,18 @@ linters:
     - revive
     - forbidigo
     - tagliatelle
-    - typecheck
     - goconst
     - gocritic
     - gocyclo
     - govet
     - errcheck
     - gosec
-    - goimports
     - nolintlint
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
 
 linters-settings:
   forbidigo:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ SDK for every minectl product
 
 ## Breaking changes
 
+### v0.9.0
+
+- **GCE**: Refactored authentication to use Application Default Credentials (ADC) instead of JSON keyfile.
+  - `NewGCE(keyfile, zone string)` changed to `NewGCE(zone string)`
+  - `GCE_KEY` environment variable is no longer used
+  - New required environment variables: `GOOGLE_PROJECT` and `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+  - Optional: `GOOGLE_APPLICATION_CREDENTIALS` for service account JSON (if not using `gcloud auth application-default login`)
+
+- **Azure**: Removed unused `authFile` parameter from `NewAzure()` function.
+  - `NewAzure(authFile string)` changed to `NewAzure()`
+  - `AZURE_AUTH_LOCATION` environment variable is no longer used
+  - No changes needed if already using `AZURE_SUBSCRIPTION_ID` with `az login`
+
 ### v0.8.0
 
 - Rename `Linode` to `Akamai Connected Cloud` and all related files. See this [blog post](https://www.linode.com/blog/linode/a-bold-new-approach-to-the-cloud/) for more information.

--- a/cloud/azure/azure.go
+++ b/cloud/azure/azure.go
@@ -27,7 +27,17 @@ type Azure struct {
 	tmpl           *minctlTemplate.Template
 }
 
-func NewAzure(authFile string) (*Azure, error) {
+// NewAzure creates a new Azure instance using DefaultAzureCredential.
+// Authentication is handled automatically via the Azure credential chain:
+// 1. Environment variables (AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET)
+// 2. Managed identity (when running on Azure)
+// 3. Azure CLI authentication (az login)
+// 4. Azure PowerShell authentication
+// 5. Azure Developer CLI authentication
+//
+// Required environment variables:
+// - AZURE_SUBSCRIPTION_ID: The Azure subscription ID
+func NewAzure() (*Azure, error) {
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Refactored GCE authentication to use Application Default Credentials (ADC) instead of JSON keyfile
- Removed unused `authFile` parameter from Azure's `NewAzure()` function
- Updated golangci-lint config to v2 format

## Breaking Changes

### GCE
- `NewGCE(keyfile, zone string)` changed to `NewGCE(zone string)`
- `GCE_KEY` environment variable is no longer used
- New required environment variables: `GOOGLE_PROJECT` and `GOOGLE_SERVICE_ACCOUNT_EMAIL`
- Optional: `GOOGLE_APPLICATION_CREDENTIALS` for service account JSON (if not using `gcloud auth application-default login`)

### Azure
- `NewAzure(authFile string)` changed to `NewAzure()`
- `AZURE_AUTH_LOCATION` environment variable is no longer used (it was never actually used in the implementation)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] golangci-lint runs successfully